### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylon_data_extract.yml
+++ b/.github/workflows/pylon_data_extract.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 12 * * *'   # daily at 8am ET
   workflow_dispatch:       # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/langchain-ai/pylon_data_extractor/security/code-scanning/1](https://github.com/langchain-ai/pylon_data_extractor/security/code-scanning/1)

In general, the fix is to explicitly set `permissions` for the workflow or individual jobs so that the `GITHUB_TOKEN` has only the privileges required. Since this workflow only needs to read the repository contents (for `actions/checkout`) and does not appear to write anything back to GitHub (no pushes, PR changes, issue edits, or artifact uploads requiring elevated scopes), we can safely restrict `permissions` to `contents: read`. This both satisfies the CodeQL check and adheres to least-privilege principles.

The best, minimal-impact fix is to add a root-level `permissions` block directly under the workflow `name:` (or just after the `on:` block; both are valid, but putting it near the top is conventional). That block should specify `contents: read`. No other permissions appear necessary from the provided snippet. No additional imports or methods are relevant because this is a YAML workflow definition, not application code. Concretely, in `.github/workflows/pylon_data_extract.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file so that it applies to all jobs in the workflow, including the `run` job on line 9. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
